### PR TITLE
Correção link meetup WP Fortaleza

### DIFF
--- a/index.html
+++ b/index.html
@@ -407,7 +407,7 @@
                         <li><a href="http://www.meetup.com/pt/WordPress-Brasilia/" title="Grupo de Meetup sobre WordPress em Brasília">Brasília</a></li>
                         <li><a href="http://www.meetup.com/pt/WordPress-Meetup-Cariri/" title="Grupo de Meetup sobre WordPress em Cariri">Cariri</a></li>
                         <li><a href="http://www.meetup.com/wpcuritiba/" title="Grupo de Meetup sobre WordPress em Curitiba">Curitiba</a></li>
-                        <li><a href="http://www.meetup.com/pt/Fortaleza-WordPress-MeetUp/" title="Grupo de Meetup sobre WordPress em Fortaleza">Fortaleza</a></li>
+                        <li><a href="http://www.meetup.com/pt-BR/wpfortaleza/" title="Grupo de Meetup sobre WordPress em Fortaleza">Fortaleza</a></li>
                         <li><a href="http://www.meetup.com/wpjoinville/" title="Grupo de Meetup sobre WordPress em Joinville">Joinville</a></li>
                         <li><a href="http://www.meetup.com/wp-poa/" title="Grupo de Meetup sobre WordPress em Porto Alegre">Porto Alegre</a></li>
                         <li><a href="http://www.meetup.com/wp-rio" title="Grupo de Meetup sobre WordPress no Rio de Janeiro ">Rio de Janeiro</a></li>


### PR DESCRIPTION
O link anterior do meetup de Fortaleza foi desativado.